### PR TITLE
fix: adds class name to a row

### DIFF
--- a/app/assets/stylesheets/connections/_index.scss
+++ b/app/assets/stylesheets/connections/_index.scss
@@ -4,7 +4,7 @@
   }
 }
 
-.row {
+.row-suggestions {
   display: flex;
   flex-direction: column;
   justify-content: center;

--- a/app/views/connections/index.html.erb
+++ b/app/views/connections/index.html.erb
@@ -2,7 +2,7 @@
   <h2 class="pt-3 text-center"> Start your journey </h2>
   <h2 class="pt-3 mb-5 text-center"> connecting with </h2>
   <%# <%= Artist.all.name%>
-  <div class="row m-3">
+  <div class="row row-suggestions m-3">
     <% unless current_user == @user %>
       <% @profiles = Artist.all.first(3) + Label.all.first(3)  %>
       <% @profiles.each do |profile| %>


### PR DESCRIPTION
added an extra class name to row in suggestions page so specific row style only applies for that page:
@silsc please review and merge 